### PR TITLE
Add missing chmod

### DIFF
--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -133,6 +133,7 @@ on init
     mkdir /dev/cpuctl
     mount cgroup none /dev/cpuctl cpu
     chown system system /dev/cpuctl
+    chmod 0660 /dev/cpuctl
     chown system system /dev/cpuctl/tasks
     chmod 0666 /dev/cpuctl/tasks
     write /dev/cpuctl/cpu.shares 1024


### PR DESCRIPTION
fixes  SchedPolicy: add_tid_to_cgroup failed to write '12115' (Permission denied); fd=28 errors

see here https://lists.linaro.org/pipermail/linaro-android/2013-January/001821.html
